### PR TITLE
Fix tests without controllers.

### DIFF
--- a/lib/lazy_api_doc/generator.rb
+++ b/lib/lazy_api_doc/generator.rb
@@ -39,7 +39,7 @@ module LazyApiDoc
     def example_group(example, examples, route) # rubocop:disable Metrics/AbcSize
       {
         example['verb'].downcase => {
-          "tags" => [example.controller],
+          "tags" => [example.controller || 'Ungrouped'],
           "description" => example["description"].capitalize,
           "summary" => example.action,
           "parameters" => path_params(route, examples) + query_params(examples),

--- a/lib/lazy_api_doc/version.rb
+++ b/lib/lazy_api_doc/version.rb
@@ -1,3 +1,3 @@
 module LazyApiDoc
-  VERSION = "0.2.2".freeze
+  VERSION = "0.2.3".freeze
 end


### PR DESCRIPTION
Generator tags each request with its controller name, but sometimes it happens that the
request doesn't have a controller name. In this case the request will be tagged as 'Ungrouped'